### PR TITLE
Add length argument and punctuation to password command

### DIFF
--- a/pmxbot/commands.py
+++ b/pmxbot/commands.py
@@ -3,6 +3,7 @@
 import sys
 import re
 import random
+import string
 import csv
 import urllib.parse
 
@@ -387,10 +388,29 @@ def password(client, event, channel, nick, rest):
 	Generate a random password, similar to
 	http://www.pctools.com/guides/password
 	"""
-	chars = '32547698ACBEDGFHKJMNQPSRUTWVYXZacbedgfhkjmnqpsrutwvyxz'
+	charsets = [
+		string.ascii_lowercase,
+		string.ascii_uppercase,
+		string.digits,
+		string.punctuation,
+	]
 	passwd = []
-	for i in range(8):
-		passwd.append(random.choice(chars))
+
+	try:
+		length = rest.strip() or 12
+		length = int(length)
+	except ValueError:
+		return 'need an integer password length!'
+
+	for i in range(length):
+		passwd.append(random.choice(''.join(charsets)))
+
+	if length >= len(charsets):
+		# Ensure we have at least one character from each charset
+		replacement_indices = random.sample(range(length), len(charsets))
+		for i, charset in zip(replacement_indices, charsets):
+			passwd[i] = random.choice(charset)
+
 	return ''.join(passwd)
 
 

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -1,5 +1,6 @@
 import re
 import os
+import string
 import uuid
 import urllib.error
 
@@ -485,3 +486,45 @@ class TestCommands:
 		result = ''.join(lines)
 		assert 'help' in result
 		assert result == '!help: Help (this command)'
+
+	def test_password(self):
+		"""
+		Test the default password command.
+
+		Result should include at least one ascii character, digit,
+		and punctuation character.
+		"""
+		res = commands.password(c, e, '#test', 'testrunner', '')
+		assert len(res) == 12
+		assert any(char in res for char in string.ascii_letters)
+		assert any(char in res for char in string.digits)
+		assert any(char in res for char in string.punctuation)
+
+	@pytest.mark.parametrize(["length"], [[val] for val in range(4, 100)])
+	def test_password_specific(self, length):
+		"""
+		Test the password command (with a length argument >= 4).
+		"""
+		res = commands.password(c, e, '#test', 'testrunner', str(length))
+		assert len(res) == int(length)
+		assert any(char in res for char in string.ascii_letters)
+		assert any(char in res for char in string.digits)
+		assert any(char in res for char in string.punctuation)
+
+	@pytest.mark.parametrize(["length"], [[val] for val in range(1, 4)])
+	def test_password_specific_short(self, length):
+		"""
+		Test the password command with a length argument < 4.
+
+		With passwords this short we can't guarantee they'll
+		contain one of each character set.
+		"""
+		res = commands.password(c, e, '#test', 'testrunner', str(length))
+		assert len(res) == int(length)
+
+	def test_password_nonint(self):
+		"""
+		Test the password command with a non-integer argument.
+		"""
+		res = commands.password(c, e, '#test', 'testrunner', 'test')
+		assert res == 'need an integer password length!'


### PR DESCRIPTION
This commit changes the !password command to use a wider range of
characters when creating the output password: lower and upper case ascii
characters, digits, and punctuation characters.

It also allows a parameter to be passed to the command to specify the
length of the password (default 12; see
https://blog.codinghorror.com/your-password-is-too-damn-short/).

If the length provided is greater than or equal to 3, the password is
guaranteed to include at least one of each type of character.