### PR TITLE
Add New Relic integration

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,7 @@ in setup.py. Some optional dependencies are installed with
 - irc: IRC bot client.
 - slack: Slack bot client.
 - viewer: Enable the web viewer application.
+- newrelic: Integrate with New Relic (Currently only available for YouGov internal usage)
 
 Testing
 =======

--- a/config.yaml
+++ b/config.yaml
@@ -34,3 +34,5 @@ TCP keepalive: 30 seconds
 
 # set a rate limit on outgoing messages in messages per second
 message rate limit: 2.5
+
+newrelic_license_key: ''

--- a/pmxbot/core.py
+++ b/pmxbot/core.py
@@ -581,6 +581,7 @@ def initialize(config):
 	config = init_config(config)
 
 	_setup_logging()
+	_setup_newrelic(config)
 	_load_library_extensions()
 	if not Handler._registry:
 		raise RuntimeError("No handlers registered")
@@ -645,3 +646,23 @@ def _load_filters():
 	group = 'pmxbot_filters'
 	eps = pkg_resources.iter_entry_points(group=group)
 	return [ep.load() for ep in eps]
+
+
+def _setup_newrelic(config):
+	"""
+	Initialize yg.newrelic if the package is installed and the
+	New Relic license key is in the config.
+	"""
+	try:
+		import yg.newrelic
+	except ImportError:
+		log.info('New Relic not initialized, yg.newrelic not installed')
+		return
+
+	nr_key = config.get('newrelic_license_key')
+	app_name = config.get('newrelic_appname', 'pmxbot')
+	if nr_key:
+		yg.newrelic.initialize(app_name, nr_key, {})
+		log.info('New Relic initialized')
+	else:
+		log.info('Cannot initialize New Relic, config missing license key')

--- a/setup.py
+++ b/setup.py
@@ -50,9 +50,11 @@ params = dict(
 		'viewer': ['cherrypy>=3.2.3', 'jinja2'],
 		'slack': ['slackclient', 'slacker'],
 		'irc': ['irc>=15.0,<16dev'],
+		'newrelic': ['yg.newrelic>=1.13,<2dev'],
 	},
 	setup_requires=[
 		'setuptools_scm>=1.15.0',
+		'wheel>=0.25.0',
 	],
 	classifiers=[
 		"Development Status :: 5 - Production/Stable",


### PR DESCRIPTION
I had to force wheel>=0.25.0 due to the newrelic wheel not being installable on Linux and Python 3.5 (Issue similar to https://bitbucket.org/pypa/wheel/issues/146/wheel-building-fails-on-cpython-350b3).