### PR TITLE
A small change to the "appreciate" command so that you can list the reason for the apprciation.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 dist/
 build/
 *.egg-info/
+pmxbot.sqlite
+.tox/
+.cache/

--- a/pmxbot/commands.py
+++ b/pmxbot/commands.py
@@ -257,11 +257,14 @@ def zinger(rest):
 	return "OH MAN!!! %s TOTALLY GOT ZING'D!" % (name.upper())
 
 
-@command(aliases=("m", "appreciate", "thanks", "thank", "gracias"))
+@command(aliases=("m", "appreciate", "thanks", "thank", "gracias", "grazie"))
 def motivate(channel, rest):
 	"Motivate someone"
 	if rest:
 		r = rest.strip()
+		m = re.match(r'^(.+)\s*\bfor\b\s*(.+)$', r)
+		if m:
+			r = m.groups()[0].strip()
 	else:
 		r = channel
 	karma.Karma.store.change(r, 1)

--- a/tests/unit/test_commands.py
+++ b/tests/unit/test_commands.py
@@ -102,6 +102,17 @@ class TestCommands:
 		post = karma.Karma.store.lookup(subject)
 		assert post == pre + 1
 
+	def test_motivate_with_reason(self):
+		"""
+		Test that motivate ignores the reason
+		"""
+		subject = "foo"
+		pre = karma.Karma.store.lookup(subject)
+		res = commands.motivate(channel="#test", rest=" %s\tfor some really incredible reason" % subject)
+		assert res == "you're doing good work, %s!" % subject
+		post = karma.Karma.store.lookup(subject)
+		assert post == pre + 1
+
 	def test_motivate_with_spaces(self):
 		"""
 		Test that motivate strips beginning and ending whitespace


### PR DESCRIPTION
For example:
!thanks jaraco for publishing pmxbot.

The command now looks for "for" in the "rest", and strips it out with the reason before applying karma and responding.

I also added the two directories and the file created when running tox tests to the .gitignore.