### PR TITLE
Fix regexp docs and add a functional test for the same

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -144,8 +144,8 @@ A more complicated response (when you want to extract data from a message) uses
 the @regexp decorator::
 
     @regexp("jira", r"(?<![a-zA-Z0-9/])(OPS|LIB|SALES|UX|GENERAL|SUPPORT)-\d\d+")
-    def jira(client, event, channel, nick, match_obj):
-        return "https://jira.example.com/browse/%s" % match_obj.group()
+    def jira(client, event, channel, nick, match):
+        return "https://jira.example.com/browse/%s" % match.group()
 
 For an example of how to implement a setuptools-based plugin, see one of the
 many examples in the pmxbot project itself or one of the popular third-party

--- a/tests/functional/plugins/pmxbot_test_commands.py
+++ b/tests/functional/plugins/pmxbot_test_commands.py
@@ -16,8 +16,7 @@ def crash_in_iterator():
 @core.regexp('feck', r'\bfeck\b', doc="We don't use that sort of language around here")
 def foobar(client, event, channel, nick, match):
     if match:
-        yield "Clean up your language %s" % nick
-        yield repr(match)
+        return "Clean up your language %s" % nick
 
 @core.command()
 def echo(rest):

--- a/tests/functional/plugins/pmxbot_test_commands.py
+++ b/tests/functional/plugins/pmxbot_test_commands.py
@@ -13,6 +13,11 @@ def crash_in_iterator():
 	raise TypeError("You should never call this!")
 	yield "You can't touch this"
 
+@core.regexp('feck', r'\bfeck\b', doc="We don't use that sort of language around here")
+def foobar(client, event, channel, nick, match):
+    if match:
+        yield "Clean up your language %s" % nick
+        yield repr(match)
 
 @core.command()
 def echo(rest):

--- a/tests/functional/test_regexps.py
+++ b/tests/functional/test_regexps.py
@@ -1,0 +1,13 @@
+import time
+
+from tests.functional import PmxbotHarness
+
+class TestPmxbotRegexp(PmxbotHarness):
+	def test_feck(self):
+		"""
+		We send a command to the logged channel to make sure that the
+		reponse happens
+		"""
+		self.client.send_message('#logged', 'What the feck?!')
+		time.sleep(0.2)
+		assert self.check_logs('#logged', nick="pmxbotTest", message="Clean up your language testingbot")


### PR DESCRIPTION
I'm not sure, but at some point the function signature for a regexp handler and the README got out of sync. This fixes that documentation, and adds a functional test so that it won't break silently again.