### PR TITLE
Expand slack references to users and channels before sending a messag…

### DIFF
--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -1,6 +1,7 @@
 import time
 import importlib
 import logging
+import re
 
 from tempora import schedule
 
@@ -64,4 +65,36 @@ class Bot(pmxbot.core.Bot):
 			self.slack.server.channels.find(channel) or
 			self._find_user_channel(username=channel)
 		)
+		message = self._expand_slack_references(message)
+
 		target.send_message(message, thread=getattr(channel, 'thread', None))
+
+	def _expand_slack_references(self, message):
+
+		def _fetch_slack_reference(match_type, match_name):
+			if match_type == '@':  # user
+				return self.slacker.users.get_user_id(match_name)
+
+			elif match_type == '#':  # channel
+				return self.slacker.channels.get_channel_id(match_name)
+
+		def _expand(match):
+			match_type = match.groupdict()['type']
+			match_name = match.groupdict()['name']
+
+			try:
+				ref = _fetch_slack_reference(match_type, match_name)
+			except Exception as e:
+				# capture any exception, fallback to original text
+				ref = None
+				log.exception(e)
+
+			if ref:
+				# found the correct reference
+				return '<{}{}>'.format(match_type, ref)
+			else:
+				return '{}{}'.format(match_type, match_name)
+
+		regex = r'(?P<type>[@|#])(?P<name>[\w\d\.\-_]*)'
+		slack_refs = re.compile(regex)
+		return slack_refs .sub(_expand, message)

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -97,4 +97,4 @@ class Bot(pmxbot.core.Bot):
 
 		regex = r'(?P<type>[@|#])(?P<name>[\w\d\.\-_]*)'
 		slack_refs = re.compile(regex)
-		return slack_refs .sub(_expand, message)
+		return slack_refs.sub(_expand, message)


### PR DESCRIPTION
…e to slack

Slack API requires that we should pass user or channel references using it slack id instead of the actual name, `@darwin` becomes `<@ABC123>` and `#python` becomes `<#XYZ098>`.

With this PR I'm adding to pmxbot the ability to expand references to users and channels, when present.