### PR TITLE
Fix parsing messages from other bots

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,9 @@
+1122.2
+======
+
+* #77: In Slack message handling, nicks are now resolved
+  for the bot_message subtype.
+
 1122.1
 ======
 

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -36,19 +36,30 @@ class Bot(pmxbot.core.Bot):
 		if msg.get('type') != 'message':
 			return
 
-		if msg.get('user'):
-			nick = self.slack.server.users.find(msg['user']).name
-		elif msg.get('username'):
-			nick = msg['username']
-		else:
-			log.warning("Unknown message %s", msg)
+		# resolve nick based on message subtype
+		# https://api.slack.com/events/message
+		method_name = '_resolve_nick_{subtype}'.format_map(
+			collections.defaultdict(lambda: 'standard', msg),
+		)
+		resolve_nick = getattr(self, method_name, None)
+		if not resolve_nick:
+			log.debug('Unhandled message %s', msg)
 			return
-
+		nick = resolve_nick(msg)
+		
 		channel = self.slack.server.channels.find(msg['channel']).name
 		channel = core.AugmentableMessage(channel, thread=msg.get('thread_ts'))
 
 		self.handle_action(channel, nick, msg['text'])
 
+	def _resolve_nick_standard(self, msg):
+		return self.slack.server.users.find(msg['user']).name
+	
+	_resolve_nick_me_message = _resolve_nick_standard
+	
+	def _resolve_nick_bot_message(self, msg):
+		return msg['username']
+	
 	def _find_user_channel(self, username):
 		"""
 		Use slacker to resolve the username to an opened IM channel

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -35,12 +35,16 @@ class Bot(pmxbot.core.Bot):
 	def handle_message(self, msg):
 		if msg.get('type') != 'message':
 			return
-		if not msg.get('user'):
+		
+		if msg.get('user'):
+			nick = self.slack.server.users.find(msg['user']).name
+		elif msg.get('username'):
+			nick = msg['username']
+		else:
 			log.warning("Unknown message %s", msg)
 			return
+		
 		channel = self.slack.server.channels.find(msg['channel']).name
-		nick = self.slack.server.users.find(msg['user']).name
-
 		channel = core.AugmentableMessage(channel, thread=msg.get('thread_ts'))
 
 		self.handle_action(channel, nick, msg['text'])

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -2,6 +2,7 @@ import time
 import importlib
 import logging
 import re
+import collections
 
 from tempora import schedule
 
@@ -46,7 +47,7 @@ class Bot(pmxbot.core.Bot):
 			log.debug('Unhandled message %s', msg)
 			return
 		nick = resolve_nick(msg)
-		
+
 		channel = self.slack.server.channels.find(msg['channel']).name
 		channel = core.AugmentableMessage(channel, thread=msg.get('thread_ts'))
 
@@ -54,12 +55,12 @@ class Bot(pmxbot.core.Bot):
 
 	def _resolve_nick_standard(self, msg):
 		return self.slack.server.users.find(msg['user']).name
-	
+
 	_resolve_nick_me_message = _resolve_nick_standard
-	
+
 	def _resolve_nick_bot_message(self, msg):
 		return msg['username']
-	
+
 	def _find_user_channel(self, username):
 		"""
 		Use slacker to resolve the username to an opened IM channel

--- a/pmxbot/slack.py
+++ b/pmxbot/slack.py
@@ -35,7 +35,7 @@ class Bot(pmxbot.core.Bot):
 	def handle_message(self, msg):
 		if msg.get('type') != 'message':
 			return
-		
+
 		if msg.get('user'):
 			nick = self.slack.server.users.find(msg['user']).name
 		elif msg.get('username'):
@@ -43,7 +43,7 @@ class Bot(pmxbot.core.Bot):
 		else:
 			log.warning("Unknown message %s", msg)
 			return
-		
+
 		channel = self.slack.server.channels.find(msg['channel']).name
 		channel = core.AugmentableMessage(channel, thread=msg.get('thread_ts'))
 


### PR DESCRIPTION
On Slack when a message comes from another bot it won't have a valid `user` field, instead the nick of the author is still available in `username`.

We use pmxbot to handle messages sent by other Slack services and this bug was causing them being discarded when we switched to using the slack connector instead of the IRC gateway.
With proposed change all the message from bots are now properly handled again on slack connector too.