### PR TITLE
Avoid slack rate limiter failures when decoding channels and users

### DIFF
--- a/newsfragments/111.feature.rst
+++ b/newsfragments/111.feature.rst
@@ -1,0 +1,1 @@
+Avoid Slack rate limiter failures when decoding channels and users

--- a/pmxbot/core.py
+++ b/pmxbot/core.py
@@ -430,7 +430,7 @@ class Bot(metaclass=abc.ABCMeta):
 
     @classmethod
     @abc.abstractmethod
-    def from_config(cls, config):
+    def from_config(cls, config):  # pragma: no cover
         raise NotImplementedError("Must implement `from_config`")
 
     def out(self, channel, s, log=True):

--- a/pmxbot/irc.py
+++ b/pmxbot/irc.py
@@ -68,6 +68,16 @@ class LoggingCommandBot(core.Bot, irc.bot.SingleServerIRCBot):
         self._nickname = nickname
         self.warn_history = WarnHistory()
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(
+            config.get('server_host', 'localhost'),
+            config.get('server_port', 6667),
+            config.bot_nickname,
+            config.log_channels + config.other_channels,
+            config.get('password'),
+        )
+
     def connect(self, *args, **kwargs):
         factory = irc.connection.Factory(wrapper=self._get_wrapper())
         res = super().connect(connect_factory=factory, *args, **kwargs)

--- a/tests/unit/test_core.py
+++ b/tests/unit/test_core.py
@@ -4,7 +4,10 @@ import copy
 import pytest
 from tempora.schedule import DelayedCommand, now
 
-from pmxbot.core import AtHandler, Scheduled, command, Handler
+from pmxbot.core import AtHandler, Handler, Scheduled, command, initialize
+from pmxbot.dictlib import ConfigDict
+from pmxbot import irc
+from pmxbot import slack
 
 
 class DelayedCommandMatch:
@@ -26,6 +29,164 @@ def patch_handler_registry(monkeypatch):
     Ensure Handler._registry is not mutated by these tests.
     """
     monkeypatch.setattr(Handler, '_registry', [])
+
+
+@pytest.fixture
+def logging_command_irc_bot_config():
+    return ConfigDict({
+        "server_host": "irc.example.com",
+        "server_port": 23,
+        "password": "some-secret",
+        "bot_nickname": "test-bot",
+        "log_channels": ["sample-log-channel"],
+        "other_channels": ["sample-other-chan", "sample-other-chan2"],
+    })
+
+
+@pytest.fixture
+def silent_command_irc_bot_config(logging_command_irc_bot_config):
+    config = ConfigDict(logging_command_irc_bot_config)
+    config["bot class"] = "pmxbot.irc:SilentCommandBot"
+    return config
+
+
+@pytest.fixture
+def slack_bot_config():
+    return ConfigDict({
+        "slack token": "sample_slack_token",
+        "slack_cache_ttl": 3600,
+        "slack_pagesize": 1,
+    })
+
+
+@pytest.fixture(
+    params=[
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": 1000,
+            "slack_pagesize": 0,
+        },
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": 1000,
+            "slack_pagesize": -1,
+        },
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": 1000,
+            "slack_pagesize": 10000,
+        },
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": 0,
+            "slack_pagesize": 0,
+        },
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": -1,
+            "slack_pagesize": -1,
+        },
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": 0,
+            "slack_pagesize": 10,
+        },
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": -1,
+            "slack_pagesize": 10,
+        },
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": "test",
+            "slack_pagesize": 10,
+        },
+        {
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": 10,
+            "slack_pagesize": "test",
+        },
+    ]
+)
+def slack_bot_invalid_config(request):
+    return ConfigDict(request.param)
+
+
+def test_initialize_irc_bot_with_defaults():
+    config = ConfigDict()
+    bot = initialize(config)
+
+    assert isinstance(bot, irc.LoggingCommandBot)
+    assert bot.nickname == "pmxbot"
+    assert bot._nickname == "pmxbot"
+    assert bot._realname == "pmxbot"
+    assert bot._channels == []
+    assert bot.servers[0].host == "localhost"
+    assert bot.servers[0].port == 6667
+    assert bot.servers[0].password is None
+
+
+def test_initialize_logging_command_irc_bot(logging_command_irc_bot_config):
+    bot = initialize(logging_command_irc_bot_config)
+
+    assert isinstance(bot, irc.LoggingCommandBot)
+    assert bot.nickname == "test-bot"
+    assert bot._nickname == "test-bot"
+    assert bot._realname == "test-bot"
+    assert bot.servers[0].host == "irc.example.com"
+    assert bot.servers[0].port == 23
+    assert bot.servers[0].password == "some-secret"
+    assert bot._channels == [
+        "sample-log-channel",
+        "sample-other-chan",
+        "sample-other-chan2",
+    ]
+
+
+def test_initialize_silent_command_irc_bot(silent_command_irc_bot_config):
+    bot = initialize(silent_command_irc_bot_config)
+
+    assert isinstance(bot, irc.SilentCommandBot)
+    assert bot.nickname == "test-bot"
+    assert bot._nickname == "test-bot"
+    assert bot._realname == "test-bot"
+    assert bot.servers[0].host == "irc.example.com"
+    assert bot.servers[0].port == 23
+    assert bot.servers[0].password == "some-secret"
+    assert bot._channels == [
+        "sample-log-channel",
+        "sample-other-chan",
+        "sample-other-chan2",
+    ]
+
+
+def test_initialize_slack_bot_with_defaults(slack_bot_config):
+    bot = initialize(
+        ConfigDict({
+            "slack token": "sample_slack_token",
+            "slack_cache_ttl": None,
+            "slack_pagesize": None,
+        })
+    )
+
+    assert isinstance(bot, slack.Bot)
+    assert bot.slack.token == "sample_slack_token"
+    assert bot.slack_cache_ttl == slack.DEFAULT_SLACK_CACHE_TTL
+    assert bot.slack_pagesize == slack.DEFAULT_SLACK_PAGESIZE
+
+
+def test_initialize_slack_bot(slack_bot_config):
+    bot = initialize(slack_bot_config)
+
+    assert isinstance(bot, slack.Bot)
+    assert bot.slack.token == "sample_slack_token"
+    assert bot.slack_cache_ttl == 3600
+    assert bot.slack_pagesize == 1
+
+
+def test_invalid_initialize_slack_bot(slack_bot_invalid_config):
+    with pytest.raises(ValueError):
+        initialize(slack_bot_invalid_config)
 
 
 @pytest.mark.usefixtures("patch_handler_registry")

--- a/tests/unit/test_slack.py
+++ b/tests/unit/test_slack.py
@@ -1,15 +1,13 @@
 import pytest
 from unittest.mock import MagicMock, patch
 
-import pmxbot
 from pmxbot import slack
 
 
 @pytest.fixture
 def slack_bot():
     with patch("slack_sdk.rtm_v2.RTMClient"):
-        pmxbot.config['slack token'] = "fake token"
-        slack_bot = slack.Bot("fake", 666, "test-bot", ["some-channel"])
+        slack_bot = slack.Bot("fake token", 1, 1)
         return slack_bot
 
 

--- a/tests/unit/test_slack.py
+++ b/tests/unit/test_slack.py
@@ -1,0 +1,230 @@
+import pytest
+from unittest.mock import MagicMock, patch
+
+import pmxbot
+from pmxbot import slack
+
+
+@pytest.fixture
+def slack_bot():
+    with patch("slack_sdk.rtm_v2.RTMClient"):
+        pmxbot.config['slack token'] = "fake token"
+        slack_bot = slack.Bot("fake", 666, "test-bot", ["some-channel"])
+        return slack_bot
+
+
+@pytest.fixture
+def slack_user_list():
+    user_list = iter([
+        {
+            "members": [
+                {
+                    "id": "foo1",
+                    "name": "foo1",
+                    "profile": {"email": "foo1@example.com"},
+                },
+                {
+                    "id": "foo2",
+                    "name": "foo2",
+                    "profile": {"email": "foo2@example.com"},
+                },
+                {
+                    "id": "foo3",
+                    "name": "foo3",
+                    "profile": {"email": "foo3@example.com"},
+                },
+                {
+                    "id": "foo4",
+                    "name": "foo4",
+                    "profile": {"email": "foo4@example.com"},
+                },
+            ]
+        },
+        {
+            "members": [
+                {
+                    "id": "bar1",
+                    "name": "bar1",
+                    "profile": {"email": "bar1@example.com"},
+                },
+                {
+                    "id": "bar2",
+                    "name": "bar2",
+                    "profile": {"email": "bar2@example.com"},
+                },
+                {
+                    "id": "bar3",
+                    "name": "bar3",
+                    "profile": {"email": "bar3@example.com"},
+                },
+                {
+                    "id": "bar4",
+                    "name": "bar4",
+                    "profile": {"email": "bar4@example.com"},
+                },
+            ]
+        },
+        {
+            "members": [
+                {
+                    "id": "baz1",
+                    "name": "baz1",
+                    "profile": {"email": "baz1@example.com"},
+                },
+                {
+                    "id": "baz2",
+                    "name": "baz2",
+                    "profile": {},
+                },
+                {
+                    "id": "baz3",
+                    "name": "baz3",
+                    "profile": {"email": "baz3@example.com"},
+                },
+            ]
+        },
+    ])
+    return user_list
+
+
+@pytest.fixture
+def slack_conversation_list():
+    conversation_list = iter([
+        {
+            "channels": [
+                {
+                    "id": "foo1",
+                    "name": "foo1",
+                },
+                {
+                    "id": "foo2",
+                    "name": "foo2",
+                },
+                {
+                    "id": "foo3",
+                    "name": "foo3",
+                },
+                {
+                    "id": "foo4",
+                    "name": "foo4",
+                },
+            ]
+        },
+        {
+            "channels": [
+                {
+                    "id": "bar1",
+                    "name": "bar1",
+                },
+                {
+                    "id": "bar2",
+                    "name": "bar2",
+                },
+                {
+                    "id": "bar3",
+                    "name": "bar3",
+                },
+                {
+                    "id": "bar4",
+                    "name": "bar4",
+                },
+            ]
+        },
+        {
+            "channels": [
+                {
+                    "id": "baz1",
+                    "name": "baz1",
+                },
+                {
+                    "id": "baz2",
+                    "name": "baz2",
+                },
+                {
+                    "id": "baz3",
+                    "name": "baz3",
+                },
+            ]
+        },
+    ])
+    return conversation_list
+
+
+@pytest.mark.parametrize(
+    ["user_name", "user_id"],
+    (
+        ["not-existing", None],
+        ["foo1", "foo1"],
+        ["FOO4", "foo4"],
+        ["bar2", "bar2"],
+        ["baz3", "baz3"],
+    ),
+)
+def test_get_id_for_user_name(user_name, user_id, slack_bot, slack_user_list):
+    slack.iter_cursor = MagicMock(return_value=slack_user_list)
+    assert slack_bot.get_id_for_user_name(user_name) == user_id
+    slack.iter_cursor.assert_called_once()
+
+
+def test_cached_get_id_for_user_name(slack_bot, slack_user_list):
+    slack.iter_cursor = MagicMock(return_value=slack_user_list)
+    slack_bot.get_id_for_user_name("foo1")
+    slack_bot.get_id_for_user_name("bar1")
+    slack_bot.get_id_for_user_name("baz1")
+    slack_bot.get_id_for_user_name("anything")
+
+    slack.iter_cursor.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ["user_email", "user_id"],
+    (
+        ["something@example.com", None],
+        ["foo1@example.com", "foo1"],
+        ["FOO4@example.com", "foo4"],
+        ["bar2@example.com", "bar2"],
+        ["baz3@example.com", "baz3"],
+    ),
+)
+def test_get_id_for_user_email(user_email, user_id, slack_bot, slack_user_list):
+    slack.iter_cursor = MagicMock(return_value=slack_user_list)
+    assert slack_bot.get_id_for_user_email(user_email) == user_id
+    slack.iter_cursor.assert_called_once()
+
+
+def test_cached_get_id_for_user_email(slack_bot, slack_user_list):
+    slack.iter_cursor = MagicMock(return_value=slack_user_list)
+    slack_bot.get_id_for_user_email("foo1@example.com")
+    slack_bot.get_id_for_user_email("bar1@example.com")
+    slack_bot.get_id_for_user_email("baz1@example.com")
+    slack_bot.get_id_for_user_email("anything")
+
+    slack.iter_cursor.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    ["channel_name", "channel_id"],
+    (
+        ["#not-found", None],
+        ["#FOO2", "foo2"],
+        ["#Foo3", "foo3"],
+        ["#bar4", "bar4"],
+        ["#baz2", "baz2"],
+    ),
+)
+def test_get_id_for_channel_name(
+    channel_name, channel_id, slack_bot, slack_conversation_list
+):
+    slack.iter_cursor = MagicMock(return_value=slack_conversation_list)
+    assert slack_bot.get_id_for_channel_name(channel_name) == channel_id
+    slack.iter_cursor.assert_called_once()
+
+
+def test_cached_get_id_for_channel_name(slack_bot, slack_conversation_list):
+    slack.iter_cursor = MagicMock(return_value=slack_conversation_list)
+    slack_bot.get_id_for_channel_name("#foo1")
+    slack_bot.get_id_for_channel_name("#bar1")
+    slack_bot.get_id_for_channel_name("#baz1")
+    slack_bot.get_id_for_channel_name("#anything")
+
+    slack.iter_cursor.assert_called_once()

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,7 @@ extras =
     testing
     irc
     mongodb
+    slack
     viewer
 
 [testenv:diffcov]


### PR DESCRIPTION
This PR includes the following:

1. Restore the `__init__` file on main module, needed for starting and importing properly

2. Change the way in which users and channels are retrieved from Slack APIs, adding a timed cache layer on top of the integration. This is needed since too many concurrent calls exceeding the specific API [web tier](https://api.slack.com/apis/rate-limits) lead to unresolved channel and/or mentions (eg. when in a message we are tagging multiple users). This new approach is more needy in terms of memory (replacing the paged iterator with a cached dictionary), but more stable and, in fact, memory should not exceed a few megabytes for hundreds of thousands users